### PR TITLE
Some Code Clean-Up

### DIFF
--- a/smc/autogen.sh
+++ b/smc/autogen.sh
@@ -36,7 +36,7 @@ case "x$1" in
 			fi
 		fi
 		echo "Removing various generated files..."
-		rm -rf aclocal.m4 config.h.in configure autom4te.cache/ build-aux/
+		rm -rf aclocal.m4 config.h.in config.guess config.sub config.rpath configure depcomp install-sh autom4te.cache/ build-aux/ m4/
 		echo "Removing 'Makefile.in's recursively..."
 		for file in `find -name Makefile.in`; do
 			rm -f $file

--- a/smc/src/core/editor.cpp
+++ b/smc/src/core/editor.cpp
@@ -32,9 +32,6 @@
 #include "../overworld/overworld.h"
 #include "../core/i18n.h"
 #include "../core/filesystem/filesystem.h"
-// boost filesystem
-#include "boost/filesystem/convenience.hpp"
-namespace fs = boost::filesystem;
 // CEGUI
 #include "CEGUIXMLParser.h"
 #include "CEGUIWindowManager.h"

--- a/smc/src/core/game_core.cpp
+++ b/smc/src/core/game_core.cpp
@@ -31,9 +31,6 @@
 #include "../gui/menu_data.h"
 #include "../user/savegame.h"
 #include "../overworld/world_editor.h"
-// boost filesystem
-#include "boost/filesystem/convenience.hpp"
-namespace fs = boost::filesystem;
 // CEGUI
 #include "CEGUIWindowManager.h"
 #include "elements/CEGUIProgressBar.h"

--- a/smc/src/enemies/eato.cpp
+++ b/smc/src/enemies/eato.cpp
@@ -20,9 +20,6 @@
 #include "../video/gl_surface.h"
 #include "../core/i18n.h"
 #include "../core/filesystem/filesystem.h"
-// boost filesystem
-#include "boost/filesystem/convenience.hpp"
-namespace fs = boost::filesystem;
 // CEGUI
 #include "CEGUIXMLAttributes.h"
 #include "CEGUIWindowManager.h"

--- a/smc/src/enemies/flyon.cpp
+++ b/smc/src/enemies/flyon.cpp
@@ -23,9 +23,6 @@
 #include "../video/gl_surface.h"
 #include "../core/i18n.h"
 #include "../core/filesystem/filesystem.h"
-// boost filesystem
-#include "boost/filesystem/convenience.hpp"
-namespace fs = boost::filesystem;
 // CEGUI
 #include "CEGUIXMLAttributes.h"
 #include "CEGUIWindowManager.h"

--- a/smc/src/enemies/thromp.cpp
+++ b/smc/src/enemies/thromp.cpp
@@ -25,9 +25,6 @@
 #include "../input/mouse.h"
 #include "../core/i18n.h"
 #include "../core/filesystem/filesystem.h"
-// boost filesystem
-#include "boost/filesystem/convenience.hpp"
-namespace fs = boost::filesystem;
 // CEGUI
 #include "CEGUIXMLAttributes.h"
 #include "CEGUIWindowManager.h"

--- a/smc/src/gui/menu_data.cpp
+++ b/smc/src/gui/menu_data.cpp
@@ -35,9 +35,6 @@
 #include "../core/math/size.h"
 #include "../core/filesystem/filesystem.h"
 #include "../core/filesystem/resource_manager.h"
-// boost filesystem
-#include "boost/filesystem/convenience.hpp"
-namespace fs = boost::filesystem;
 // CEGUI
 #include "CEGUIWindowManager.h"
 #include "CEGUIFontManager.h"

--- a/smc/src/user/preferences.cpp
+++ b/smc/src/user/preferences.cpp
@@ -23,9 +23,6 @@
 #include "../core/i18n.h"
 #include "../core/filesystem/resource_manager.h"
 #include "../core/filesystem/filesystem.h"
-// boost filesystem
-#include "boost/filesystem/convenience.hpp"
-namespace fs = boost::filesystem;
 // CEGUI
 #include "CEGUIXMLParser.h"
 #include "CEGUIExceptions.h"

--- a/smc/src/video/video.cpp
+++ b/smc/src/video/video.cpp
@@ -43,9 +43,6 @@
 #include "falagard/CEGUIFalWidgetLookManager.h"
 #include "elements/CEGUIProgressBar.h"
 #include "RendererModules/Null/CEGUINullRenderer.h"
-// boost filesystem
-#include "boost/filesystem/convenience.hpp"
-namespace fs = boost::filesystem;
 // png
 #include <png.h>
 #ifndef PNG_COLOR_TYPE_RGBA


### PR DESCRIPTION
Hey Fluxy!

I was browsing SMC's code today and I realized that that `autogen.sh` script I wrote forgot to clean a few files (including the entire `m4` directory!). That's fixed now, and `./autogen.sh clean` should perfectly clean-out the auto-generated files.

Also, in preemption for an idea I'm thinking about implementing, I did some clean-up regarding file system access. There were a number of files #including Boost Filesystem when it wasn't necessary. `world_manager.cpp` was using fs::directory_iterator instead of `Get_Directory_Files()` for some reason, but I modified it. As an consequence, `filesystem.cpp` is the only file that uses Boost Filesystem directly now. Any changes to file system management should be much easier, now; i.e. if Boost FS upgrades in a backwards-incompatible way there's only one file to change!

Anyways, I've been having trouble getting into any of my own projects for awhile now so I might be doing some feature implementation over the next few days/weeks. Quintus took over scripting because he has much more free time on his hands, so if you want to check out his progress, too, I highly recommend it.

Wiedersehen,
- Luiji
